### PR TITLE
Corrected ground truth values

### DIFF
--- a/CamBench_Cap/src/main/java/org/cambench/cap/fieldsensitivity/advanced/fielddepth2/falsepositive/smallkeysize/SmallKeySize1_meta.yaml
+++ b/CamBench_Cap/src/main/java/org/cambench/cap/fieldsensitivity/advanced/fielddepth2/falsepositive/smallkeysize/SmallKeySize1_meta.yaml
@@ -10,7 +10,7 @@ description:
   create a KeyPair and initialize an instance of the RSA algorithm.
 
 crypto-usage:
-  violation: true
+  violation: false
   FUM:
     - argument_state/number_range
   location:

--- a/CamBench_Cap/src/main/java/org/cambench/cap/fieldsensitivity/advanced/fielddepth2/falsepositive/staticiv/StaticIv1_meta.yaml
+++ b/CamBench_Cap/src/main/java/org/cambench/cap/fieldsensitivity/advanced/fielddepth2/falsepositive/staticiv/StaticIv1_meta.yaml
@@ -10,7 +10,7 @@ description:
   The securely random one is then utilized to create an initialization vector and initialize an instance of the AES algorithm.
 
 crypto-usage:
-  violation: true
+  violation: false
   FUM:
     - argument_state
   location:

--- a/CamBench_Cap/src/main/java/org/cambench/cap/flowsensitivity/advanced/valueswap/truepositive/staticiv/StaticIv1_meta.yaml
+++ b/CamBench_Cap/src/main/java/org/cambench/cap/flowsensitivity/advanced/valueswap/truepositive/staticiv/StaticIv1_meta.yaml
@@ -9,7 +9,7 @@ description:
   The arrays are swapped by using a third array, s.t. in the end the static value is then used as initialization vector.
 
 crypto-usage:
-  violation: false
+  violation: true
   FUM:
     - argument_state
   location:

--- a/CamBench_Cap/src/main/java/org/cambench/cap/interprocedural3/falsepositive/brokenhash/BrokenHash1_meta.yaml
+++ b/CamBench_Cap/src/main/java/org/cambench/cap/interprocedural3/falsepositive/brokenhash/BrokenHash1_meta.yaml
@@ -9,7 +9,7 @@ description:
   based on a secure hash algorithm (SHA-256). The object is then utilized to compute the hash value of some data.
 
 crypto-usage:
-  violation: true
+  violation: false
   FUM:
     - argument_state/string_format
   location:

--- a/CamBench_Cap/src/main/java/org/cambench/cap/mixedsensitivities/contextpath/falsepositive/smallkeysize/SmallKeySize2_meta.yaml
+++ b/CamBench_Cap/src/main/java/org/cambench/cap/mixedsensitivities/contextpath/falsepositive/smallkeysize/SmallKeySize2_meta.yaml
@@ -10,7 +10,7 @@ description:
   The larger key size is then used to create a key pair and initialize an instance of the RSA algorithm.
 
 crypto-usage:
-  violation: true
+  violation: false
   FUM:
     - argument_state/number_range
   location:

--- a/CamBench_Cap/src/main/java/org/cambench/cap/objectsensitivity/advanced/multipleobjects/falsepositive/brokenhash/BrokenHash1_meta.yaml
+++ b/CamBench_Cap/src/main/java/org/cambench/cap/objectsensitivity/advanced/multipleobjects/falsepositive/brokenhash/BrokenHash1_meta.yaml
@@ -10,7 +10,7 @@ description:
   to initialize a MessageDigest object that is used to generate the hash of some data.
 
 crypto-usage:
-  violation: true
+  violation: false
   FUM:
     - argument_state/string_format
   location:


### PR DESCRIPTION
Corrected violation flags in 6 cases.
The flags were wrongly set, yet, the cases were put in the correct directory. 